### PR TITLE
Don't convert dicts to lists in _update_context().

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -210,10 +210,7 @@ class Generator:
         processor.
         """
         for item in items:
-            value = getattr(self, item)
-            if hasattr(value, 'items'):
-                value = list(value.items())  # py3k safeguard for iterators
-            self.context[item] = value
+            self.context[item] = getattr(self, item)
 
     def __str__(self):
         # return the name of the class for logging purposes


### PR DESCRIPTION
When I use the following code in a Pelican generator class
```
self.foo = {"bar": "baz"}
self._update_context(["foo"]) 
```
then the `foo` dict is converted to a list of tuples before adding it to the context. Is there a reason for this? I was certainly surprised by this behaviour when I stumbled over this yesterday in my template code.

My PR removes this conversion.

# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [ ] Ensured **tests pass** and (if applicable) updated functional test output
- [ ] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
